### PR TITLE
Fix lint errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -17,5 +18,5 @@ func GetRouter() *mux.Router {
 }
 
 func healthcheckHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("ok"))
+	log.Fatalln(w.Write([]byte("ok")))
 }

--- a/api/slack/slack.go
+++ b/api/slack/slack.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"log"
 	"net/http"
 )
 
@@ -8,5 +9,5 @@ import (
 //
 // ENDPOINT /api/slack/command
 func CommandHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("NOT IMPLEMENTED"))
+	log.Fatalln(w.Write([]byte("NOT IMPLEMENTED")))
 }

--- a/timebot/timebot.go
+++ b/timebot/timebot.go
@@ -4,8 +4,8 @@ package timebot
 
 import (
 	"fmt"
-	"time"
 	"strings"
+	"time"
 )
 
 // ParseTime takes a string and returns time.Time in time.UTC
@@ -14,7 +14,7 @@ func ParseTime(text string) (time.Time, bool) {
 
 	text = strings.Replace(text, "PST", "-0800", 1)
 	text = strings.Replace(text, "KST", "+0900", 1)
-	
+
 	isParsed := true
 	t, err := time.Parse(longForm, text)
 	if err != nil {


### PR DESCRIPTION
린트 에러를 수정합니다.

참고로 로컬에서 `golangci-lint` 받으신다음

```bash
golangci-lint run
```

치시면 됩니다


@nicewook  님 브랜치 위에 붙는 픽스입니다.
이게 붙으면 ci 올그린 예상합니다 :smile: 

#4 