### PR TITLE
Add more tests

### DIFF
--- a/timebot/timebot.go
+++ b/timebot/timebot.go
@@ -8,15 +8,28 @@ import (
 )
 
 // ParseTime takes a string and returns time.Time in time.UTC
+//
+// FIXME: Currently, it doesn't validate PST/PDT
 func ParseTime(text string) (time.Time, bool) {
 	const longForm = "2006-01-02 15:04 -0700"
 
 	text = strings.Replace(text, "PST", "-0800", 1)
+	text = strings.Replace(text, "PDT", "-0700", 1)
 	text = strings.Replace(text, "KST", "+0900", 1)
-
 	t, err := time.Parse(longForm, text)
+
 	if err != nil {
 		return t, false
 	}
+
 	return t.UTC(), true
+}
+
+// ParseAndFlipTz returns a datetime string but in other TZ
+//
+// The following conversions are supported as of now:
+//
+// 1. KST <-> PST/PDT
+func ParseAndFlipTz(text string) (string, error) {
+	return "", nil
 }

--- a/timebot/timebot_test.go
+++ b/timebot/timebot_test.go
@@ -6,23 +6,137 @@ import (
 )
 
 func TestParseTime(t *testing.T) {
-	// KST = UTC + 9
-	input := "2018-01-01 11:50 KST"
-	expected := time.Date(2018, 1, 1, 11-9, 50, 0, 0, time.UTC)
-
-	output, ok := ParseTime(input)
-
-	if !ok || output != expected {
-		t.Fatalf("Expected %v But received %v", expected, output)
+	/////////////////////////////////
+	// TEST CASES
+	/////////////////////////////////
+	var testCasesParseTime = []struct {
+		input    string
+		expected time.Time
+		ok       bool
+	}{
+		{
+			// KST = UTC + 9
+			input:    "2018-01-01 11:50 KST",
+			expected: time.Date(2018, 1, 1, 11-9, 50, 0, 0, time.UTC),
+			ok:       true,
+		},
+		{
+			// PST = UTC - 8
+			input:    "2018-12-18 14:17 PST",
+			expected: time.Date(2018, 12, 18, 14+8, 17, 0, 0, time.UTC),
+			ok:       true,
+		},
+		{
+			// PDT = UTC -7
+			input:    "2018-08-13 20:00 PDT",
+			expected: time.Date(2018, 8, 13, 20+7, 0, 0, 0, time.UTC),
+			ok:       true,
+		},
+		{
+			// Test Invalid PST/PDT case
+			// 2018-12-21 19:34 PDT is not a valid date
+			input: "2018-12-21 19:34 PDT",
+			ok:    false,
+		},
+		{
+			// "2018-08-13 19:34 PST" is not a PST
+			input: "2018-08-13 19:34 PST",
+			ok:    false,
+		},
 	}
 
-	// PST = UTC - 8
-	input = "2018-12-18 14:17 PST"
-	expected = time.Date(2018, 12, 18, 14+8, 17, 0, 0, time.UTC)
+	//////////////////////////////////
+	// REMOVE THIS LINE
+	//////////////////////////////////
+	t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
+	for _, testCase := range testCasesParseTime {
 
-	output, ok = ParseTime(input)
+		output, ok := ParseTime(testCase.input)
 
-	if !ok || output != expected {
-		t.Fatalf("Expected %v But received %v", expected, output)
+		switch {
+
+		case testCase.ok:
+			// test should succeed
+			if !ok || !output.Equal(testCase.expected) {
+				t.Fatalf("Expected %v But received %v", testCase.expected, output)
+			}
+
+		default:
+			// test should fail
+			if ok {
+				t.Fatal("Test should fail but succeeded")
+			}
+		}
+
+	}
+}
+
+func TestParseAndFlipTz(t *testing.T) {
+	/////////////////////////////////
+	// TEST CASES
+	/////////////////////////////////
+	var testCases = []struct {
+		input    string
+		expected string
+
+		// if false, it should fail
+		ok bool
+	}{
+		{
+			// Test PDT -> KST
+			input:    "2018-08-13 20:00 PDT",
+			expected: "2018-08-14 12:00 KST",
+			ok:       true,
+		},
+		{
+			// Test KST -> PDT
+			input:    "2018-08-14 12:00 KST",
+			expected: "2018-08-13 20:00 PDT",
+			ok:       true,
+		},
+		{
+			// Test KST -> PST
+			input:    "2018-12-21 19:34 PST",
+			expected: "2018-12-22 12:34 KST",
+			ok:       true,
+		},
+		{
+			// Test Invalid PST/PDT case
+			// 2018-12-21 19:34 PDT is not a valid date
+			input: "2018-12-21 19:34 PDT",
+			ok:    false,
+		},
+		{
+
+			// "2018-08-13 19:34 PST" is not a PST
+			input: "2018-08-13 19:34 PST",
+			ok:    false,
+		},
+	}
+	//////////////////////////////////
+	// REMOVE THIS LINE
+	//////////////////////////////////
+	t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
+
+	for _, testCase := range testCases {
+		ret, err := ParseAndFlipTz(testCase.input)
+
+		switch {
+		case testCase.ok:
+			// test should succeed
+			if err != nil {
+				t.Fatal("Test should succeed but failed")
+			}
+
+			if ret != testCase.expected {
+				t.Fatalf("Expected %v but received %v", testCase.expected, ret)
+			}
+		default:
+			// test should fail
+			if err == nil {
+				t.Fatal("Test should fail but succeeded")
+			}
+
+		}
 	}
 }


### PR DESCRIPTION
## Summary

1. Add PST/PDT Test Case 
2. Add the final function `func ParseAndFlipTz(text string) (string, error)`
- 탑다운 방식으로 바꿔서 우선 젤 필요한 함수 테스트를 작성했습니다
- 미국 시간 문자열을 받으면 한국 시간 문자열 반환
- 한국 시간 문자열을 받으면 미국 시간 문자열 반환

3. 현재 테스트가 실패하기 때문에 t.Skip이 들어가 있습니다.
4. 다른 필요한 함수나 다른 디자인이 있으면 얼마든지 더 작성해주세요 :smile: 

## References

`ParseInLocation` 을 사용해야 될 것 같습니다 :thinking: 

```go
	caTz, _ := time.LoadLocation("America/Los_Angeles")

	longForm := "2006-01-02 15:04 MST"

	result, _ := time.ParseInLocation(longForm, "2018-12-22 20:29 PST", caTz)
	expected := time.Date(2018, time.December, 22, 20, 29, 0, 0, caTz)

	if result.Equal(expected) {
		fmt.Println("Same")
	}
```

https://play.golang.org/p/b6z8Dkb9hUw

## Related Issues
- Resolves #6 