### PR TITLE
Pass TestParseAndFlipTz

### DIFF
--- a/timebot/timebot.go
+++ b/timebot/timebot.go
@@ -4,8 +4,6 @@ package timebot
 
 import (
 	"errors"
-	"fmt"
-
 	s "strings"
 	"time"
 )

--- a/timebot/timebot_test.go
+++ b/timebot/timebot_test.go
@@ -112,7 +112,6 @@ func TestParseAndFlipTz(t *testing.T) {
 	//////////////////////////////////
 	// REMOVE THIS LINE
 	//////////////////////////////////
-	// t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
 
 	for _, testCase := range testCases {
 		ret, err := ParseAndFlipTz(testCase.input)

--- a/timebot/timebot_test.go
+++ b/timebot/timebot_test.go
@@ -48,7 +48,7 @@ func TestParseTime(t *testing.T) {
 	//////////////////////////////////
 	// REMOVE THIS LINE
 	//////////////////////////////////
-	t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
+	// t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
 	for _, testCase := range testCasesParseTime {
 
 		output, ok := ParseTime(testCase.input)
@@ -116,7 +116,7 @@ func TestParseAndFlipTz(t *testing.T) {
 	//////////////////////////////////
 	// REMOVE THIS LINE
 	//////////////////////////////////
-	t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
+	// t.Skip("[TEST SKIP] PLEASE REMOVE THIS")
 
 	for _, testCase := range testCases {
 		ret, err := ParseAndFlipTz(testCase.input)


### PR DESCRIPTION
이미 만든 ParseTime() 을 이용
1) filpTz 으로서 PST/PDT 면 Asia/Seoul, KST 면 America/Los_Angeles 가 되도록 함
2) ParseTime() 을 이용하여 PST/PDT 에러 체크 및 UTC time 으로 1차 변경
- 바로 변경도 가능하지만 일단 PartTime() 을 재활용
3) 이후 time.In() 함수로 Flip 하고자 하는 Timezone 으로 변경후, time.Format() 으로
원하는 형태의 string 으로 변환