### PR TITLE
Add verification tests

### DIFF
--- a/api/slack/verification.go
+++ b/api/slack/verification.go
@@ -1,0 +1,15 @@
+package slack
+
+import "net/http"
+
+// Verify verifies the request is coming from Slack
+//
+// Read https://api.slack.com/docs/verifying-requests-from-slack
+func Verify(slackSigningToken, body []byte, timestamp int64, expectedHex []byte) bool {
+	return false
+}
+
+// VerifyRequest is a wrapper around `Verify`
+func VerifyRequest(req *http.Request, slackSigningToken []byte) bool {
+	return false
+}

--- a/api/slack/verification_test.go
+++ b/api/slack/verification_test.go
@@ -1,0 +1,42 @@
+package slack
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+//nolint:lll
+func TestVerify(t *testing.T) {
+	t.Skip("DELETE THIS")
+	slackSigningToken := []byte("8f742231b10e8888abcd99yyyzzz85a5")
+	body := []byte("token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c")
+	var timestamp int64 = 1531420618
+
+	expectedHex := []byte("v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503")
+
+	if ok := Verify(slackSigningToken, body, timestamp, expectedHex); !ok {
+		t.Fatal("Failed to verify")
+	}
+}
+
+//nolint:lll
+func TestVerifyRequest(t *testing.T) {
+	t.Skip("DELETE THIS")
+
+	bodyRaw := "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
+	body := bytes.NewBufferString(bodyRaw)
+	req, _ := http.NewRequest("POST", "/api/doesn'tmatter", body)
+	req.Header.Add("X-Slack-Request-Timestamp", "1531420618")
+	req.Header.Add("X-Slack-Signature", "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503")
+	slackSigningToken := []byte("8f742231b10e8888abcd99yyyzzz85a5")
+
+	if !VerifyRequest(req, slackSigningToken) {
+		t.Fatal("Failed to verify with the request object")
+	}
+
+	if b, err := ioutil.ReadAll(req.Body); err != nil || string(b) != bodyRaw {
+		t.Fatal("It should not consume body")
+	}
+}


### PR DESCRIPTION
```go
func Verify(slackSigningToken, body []byte, timestamp int64, expectedHex []byte) bool {
	return false
}
```
오피셜 가이드
https://api.slack.com/docs/verifying-requests-from-slack

* slackSigningToken 은 앱 즉 저희가 제공하는 토큰입니다
* body는 slack에서 보내진 request의 바디입니다. 내용은 상관없습니다
* timestamp는 slack에서 보내온 X-Slack-Request-Timestamp 헤더 값입니다.
* expectedHex는 slack에서 보내온 X-Slack-Signature 헤더 값입니다. 최종적으로 이 값이랑 비교를 해야 됩니다.

